### PR TITLE
Fix typo in `isWhitespace` docs

### DIFF
--- a/src/String/Extra.elm
+++ b/src/String/Extra.elm
@@ -29,7 +29,7 @@ pluralize singular plural count =
         (toString count) ++ " " ++ plural
 
 
-{-| Returns True iff the given String is 1 or more whitespace characters,
+{-| Returns True if the given String is 1 or more whitespace characters,
 and nothing else.
 
 (Whitespace is defined as the regular expression `\s` matcher.)


### PR DESCRIPTION
The teeniest typo - thought I'd do the easy fix whilst I was there :)
